### PR TITLE
Show scientific notation when metrics' values are too small or too large

### DIFF
--- a/src/training_loop/progress_reporter.py
+++ b/src/training_loop/progress_reporter.py
@@ -16,12 +16,12 @@ class ProgressReporter(AbstractContextManager):
     """
 
     def __init__(
-        self,
-        epoch: int,
-        *,
-        total_epochs: int,
-        total_batches: int | float = float("inf"),
-        verbose: int = 1,
+            self,
+            epoch: int,
+            *,
+            total_epochs: int,
+            total_batches: int | float = float("inf"),
+            verbose: int = 1,
     ) -> None:
         """
         Construct progress reporter instance for an epoch.
@@ -52,10 +52,10 @@ class ProgressReporter(AbstractContextManager):
         return self
 
     def __exit__(
-        self,
-        exc_type: type[BaseException] | None,  # noqa
-        exc_value: BaseException | None,  # noqa
-        traceback: TracebackType | None,  # noqa
+            self,
+            exc_type: type[BaseException] | None,  # noqa
+            exc_value: BaseException | None,  # noqa
+            traceback: TracebackType | None,  # noqa
     ) -> bool | None:
         self.close_report()
 
@@ -105,6 +105,7 @@ class ProgressReporter(AbstractContextManager):
 
 
 def format_metrics(metrics: dict[str, float]) -> str:
+
     def format_value(value: float) -> str:
         if 1e-3 <= value <= 1e3:
             return f"{value:.4f}"

--- a/src/training_loop/progress_reporter.py
+++ b/src/training_loop/progress_reporter.py
@@ -16,12 +16,12 @@ class ProgressReporter(AbstractContextManager):
     """
 
     def __init__(
-            self,
-            epoch: int,
-            *,
-            total_epochs: int,
-            total_batches: int | float = float('inf'),
-            verbose: int = 1,
+        self,
+        epoch: int,
+        *,
+        total_epochs: int,
+        total_batches: int | float = float("inf"),
+        verbose: int = 1,
     ) -> None:
         """
         Construct progress reporter instance for an epoch.
@@ -52,10 +52,10 @@ class ProgressReporter(AbstractContextManager):
         return self
 
     def __exit__(
-            self,
-            exc_type: type[BaseException] | None,  # noqa
-            exc_value: BaseException | None,  # noqa
-            traceback: TracebackType | None,  # noqa
+        self,
+        exc_type: type[BaseException] | None,  # noqa
+        exc_value: BaseException | None,  # noqa
+        traceback: TracebackType | None,  # noqa
     ) -> bool | None:
         self.close_report()
 
@@ -77,9 +77,9 @@ class ProgressReporter(AbstractContextManager):
         elif epoch in [1, epochs] or verbose == 2 or (epoch % verbose == 0):
             print(
                 self._get_epoch_description(desc),
-                ': ',
+                ": ",
                 format_metrics(metrics),
-                sep='',
+                sep="",
             )
 
     def report_batch_progress(self, desc: str, metrics: dict[str, float]) -> None:
@@ -92,11 +92,11 @@ class ProgressReporter(AbstractContextManager):
             self._bar.close()
 
     def _get_epoch_description(self, desc: str | None = None):
-        epoch_str = f'Epoch {self._epoch}/{self._epochs}'
-        return f'{epoch_str} - {desc}' if desc else epoch_str
+        epoch_str = f"Epoch {self._epoch}/{self._epochs}"
+        return f"{epoch_str} - {desc}" if desc else epoch_str
 
     def _set_bar_desciption(self, desc):
-        if not hasattr(self, '_cur_desc'):
+        if not hasattr(self, "_cur_desc"):
             self._cur_desc = None
 
         if self._bar and self._cur_desc != desc:
@@ -105,5 +105,11 @@ class ProgressReporter(AbstractContextManager):
 
 
 def format_metrics(metrics: dict[str, float]) -> str:
-    strs = (f'{k}={v:.4f}' for k, v in metrics.items())
-    return '; '.join(strs)
+    def format_value(value: float) -> str:
+        if 1e-3 <= value <= 1e3:
+            return f"{value:.4f}"
+        else:
+            return f"{value:.4e}"
+
+    strs = (f"{k}={format_value(v)}" for k, v in metrics.items())
+    return "; ".join(strs)

--- a/tests/progress_reporter_test.py
+++ b/tests/progress_reporter_test.py
@@ -134,19 +134,16 @@ def test_report_epoch_progress(tqdm, capsys, epoch, verbose):
     elif verbose == 1:
         bar.set_description.assert_called_once_with(f"Epoch {epoch}/100 - Finished")
         bar.set_postfix_str.assert_called_once_with(
-            "f1=0.9000; loss=0.1000; val_f1=0.8900; val_loss=0.1100"
-        )
+            "f1=0.9000; loss=0.1000; val_f1=0.8900; val_loss=0.1100")
     elif verbose == 2:
         assert stdout_str == (
             f"Epoch {epoch}/100 - Finished: "
-            "f1=0.9000; loss=0.1000; val_f1=0.8900; val_loss=0.1100\n"
-        )
+            "f1=0.9000; loss=0.1000; val_f1=0.8900; val_loss=0.1100\n")
     elif verbose > 2:
         if epoch == 1 or epoch == 100 or (epoch % verbose == 0):
             assert stdout_str == (
                 f"Epoch {epoch}/100 - Finished: "
-                "f1=0.9000; loss=0.1000; val_f1=0.8900; val_loss=0.1100\n"
-            )
+                "f1=0.9000; loss=0.1000; val_f1=0.8900; val_loss=0.1100\n")
         else:
             assert stdout_str == ""
 
@@ -184,5 +181,4 @@ def test_format_metrics_normal_floats():
     }
     result = format_metrics(metrics)
     assert (
-        result == "v1=123.4568; v2=12.3457; v3=1.2346; v4=0.1235; v5=0.0123; v6=0.0012"
-    )
+        result == "v1=123.4568; v2=12.3457; v3=1.2346; v4=0.1235; v5=0.0123; v6=0.0012")

--- a/tests/progress_reporter_test.py
+++ b/tests/progress_reporter_test.py
@@ -5,22 +5,23 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from training_loop.progress_reporter import format_metrics
 from training_loop.progress_reporter import ProgressReporter
 
 
-@pytest.mark.parametrize('verbose', [0, 1, 2, 5, 10, 30, 50])
-@patch('training_loop.progress_reporter.tqdm')
+@pytest.mark.parametrize("verbose", [0, 1, 2, 5, 10, 30, 50])
+@patch("training_loop.progress_reporter.tqdm")
 def test_init(tqdm, verbose):
     ProgressReporter(epoch=1, total_batches=100, total_epochs=10, verbose=verbose)
 
     if verbose == 1:
-        tqdm.assert_called_once_with(total=100, desc='Epoch 1/10')
+        tqdm.assert_called_once_with(total=100, desc="Epoch 1/10")
     else:
         tqdm.assert_not_called()
 
 
-@pytest.mark.parametrize('verbose', [0, 1, 2, 5, 10, 30, 50])
-@patch('training_loop.progress_reporter.tqdm')
+@pytest.mark.parametrize("verbose", [0, 1, 2, 5, 10, 30, 50])
+@patch("training_loop.progress_reporter.tqdm")
 def test_next_batch(tqdm, verbose):
     bar = MagicMock()
     tqdm.return_value = bar
@@ -39,8 +40,8 @@ def test_next_batch(tqdm, verbose):
         bar.update.assert_not_called()
 
 
-@pytest.mark.parametrize('verbose', [0, 1, 2, 5, 10, 30, 50])
-@patch('training_loop.progress_reporter.tqdm')
+@pytest.mark.parametrize("verbose", [0, 1, 2, 5, 10, 30, 50])
+@patch("training_loop.progress_reporter.tqdm")
 def test_close_report(tqdm, verbose):
     bar = MagicMock()
     tqdm.return_value = bar
@@ -59,8 +60,8 @@ def test_close_report(tqdm, verbose):
         bar.close.assert_not_called()
 
 
-@pytest.mark.parametrize('verbose', [0, 1, 2, 5, 10, 30, 50])
-@patch('training_loop.progress_reporter.tqdm')
+@pytest.mark.parametrize("verbose", [0, 1, 2, 5, 10, 30, 50])
+@patch("training_loop.progress_reporter.tqdm")
 def test_report_batch_progress(tqdm, verbose):
     bar = MagicMock()
     tqdm.return_value = bar
@@ -72,27 +73,27 @@ def test_report_batch_progress(tqdm, verbose):
         verbose=verbose,
     )
 
-    reporter.report_batch_progress('Training', {'f1': 0.1, 'loss': 0.9})
-    reporter.report_batch_progress('Training', {'f1': 0.2, 'loss': 0.8})
-    reporter.report_batch_progress('Training', {'f1': 0.3, 'loss': 0.7})
-    reporter.report_batch_progress('Validation', {'val_f1': 0.4, 'val_loss': 0.6})
-    reporter.report_batch_progress('Validation', {'val_f1': 0.55, 'val_loss': 0.45})
+    reporter.report_batch_progress("Training", {"f1": 0.1, "loss": 0.9})
+    reporter.report_batch_progress("Training", {"f1": 0.2, "loss": 0.8})
+    reporter.report_batch_progress("Training", {"f1": 0.3, "loss": 0.7})
+    reporter.report_batch_progress("Validation", {"val_f1": 0.4, "val_loss": 0.6})
+    reporter.report_batch_progress("Validation", {"val_f1": 0.55, "val_loss": 0.45})
 
     if verbose == 1:
         bar.set_description.assert_has_calls(
             [
-                call('Epoch 1/10 - Training'),
-                call('Epoch 1/10 - Validation'),
+                call("Epoch 1/10 - Training"),
+                call("Epoch 1/10 - Validation"),
             ],
             any_order=False,
         )
         bar.set_postfix_str.assert_has_calls(
             [
-                call('f1=0.1000; loss=0.9000'),
-                call('f1=0.2000; loss=0.8000'),
-                call('f1=0.3000; loss=0.7000'),
-                call('val_f1=0.4000; val_loss=0.6000'),
-                call('val_f1=0.5500; val_loss=0.4500'),
+                call("f1=0.1000; loss=0.9000"),
+                call("f1=0.2000; loss=0.8000"),
+                call("f1=0.3000; loss=0.7000"),
+                call("val_f1=0.4000; val_loss=0.6000"),
+                call("val_f1=0.5500; val_loss=0.4500"),
             ],
             any_order=False,
         )
@@ -100,9 +101,9 @@ def test_report_batch_progress(tqdm, verbose):
         bar.assert_not_called()
 
 
-@pytest.mark.parametrize('epoch', [1, 5, 10, 50, 100])
-@pytest.mark.parametrize('verbose', [0, 1, 2, 5, 10])
-@patch('training_loop.progress_reporter.tqdm')
+@pytest.mark.parametrize("epoch", [1, 5, 10, 50, 100])
+@pytest.mark.parametrize("verbose", [0, 1, 2, 5, 10])
+@patch("training_loop.progress_reporter.tqdm")
 def test_report_epoch_progress(tqdm, capsys, epoch, verbose):
     bar = MagicMock()
     tqdm.return_value = bar
@@ -114,31 +115,74 @@ def test_report_epoch_progress(tqdm, capsys, epoch, verbose):
         verbose=verbose,
     )
 
-    reporter.report_epoch_progress('Finished', {
-        'f1': 0.9,
-        'loss': 0.1,
-        'val_f1': 0.89,
-        'val_loss': 0.11,
-    })
+    reporter.report_epoch_progress(
+        "Finished",
+        {
+            "f1": 0.9,
+            "loss": 0.1,
+            "val_f1": 0.89,
+            "val_loss": 0.11,
+        },
+    )
 
     stdout_str = capsys.readouterr().out
 
     if verbose == 0:
         bar.set_description.assert_not_called()
         bar.set_postfix_str.assert_not_called()
-        assert stdout_str == ''
+        assert stdout_str == ""
     elif verbose == 1:
-        bar.set_description.assert_called_once_with(f'Epoch {epoch}/100 - Finished')
+        bar.set_description.assert_called_once_with(f"Epoch {epoch}/100 - Finished")
         bar.set_postfix_str.assert_called_once_with(
-            'f1=0.9000; loss=0.1000; val_f1=0.8900; val_loss=0.1100')
+            "f1=0.9000; loss=0.1000; val_f1=0.8900; val_loss=0.1100"
+        )
     elif verbose == 2:
         assert stdout_str == (
-            f'Epoch {epoch}/100 - Finished: '
-            'f1=0.9000; loss=0.1000; val_f1=0.8900; val_loss=0.1100\n')
+            f"Epoch {epoch}/100 - Finished: "
+            "f1=0.9000; loss=0.1000; val_f1=0.8900; val_loss=0.1100\n"
+        )
     elif verbose > 2:
         if epoch == 1 or epoch == 100 or (epoch % verbose == 0):
             assert stdout_str == (
-                f'Epoch {epoch}/100 - Finished: '
-                'f1=0.9000; loss=0.1000; val_f1=0.8900; val_loss=0.1100\n')
+                f"Epoch {epoch}/100 - Finished: "
+                "f1=0.9000; loss=0.1000; val_f1=0.8900; val_loss=0.1100\n"
+            )
         else:
-            assert stdout_str == ''
+            assert stdout_str == ""
+
+
+def test_format_metrics_large_floats():
+    metrics = {
+        "v1": 1234.5678,
+        "v2": 12345.678,
+        "v3": 123456.78,
+        "v4": 1234567.8,
+    }
+    result = format_metrics(metrics)
+    assert result == "v1=1.2346e+03; v2=1.2346e+04; v3=1.2346e+05; v4=1.2346e+06"
+
+
+def test_format_metrics_small_floats():
+    metrics = {
+        "v1": 0.00012345,
+        "v2": 0.000012345,
+        "v3": 0.0000012345,
+        "v4": 0.00000012345,
+    }
+    result = format_metrics(metrics)
+    assert result == "v1=1.2345e-04; v2=1.2345e-05; v3=1.2345e-06; v4=1.2345e-07"
+
+
+def test_format_metrics_normal_floats():
+    metrics = {
+        "v1": 123.45678,
+        "v2": 12.345678,
+        "v3": 1.2345678,
+        "v4": 0.1234567,
+        "v5": 0.0123456,
+        "v6": 0.0012345,
+    }
+    result = format_metrics(metrics)
+    assert (
+        result == "v1=123.4568; v2=12.3457; v3=1.2346; v4=0.1235; v5=0.0123; v6=0.0012"
+    )


### PR DESCRIPTION
Show scientific notation for metrics values when they're too small or too large (#29).